### PR TITLE
data.gov.ru теперь выдаёт редирект на HTTPS

### DIFF
--- a/src/Clients/DataGovClient.php
+++ b/src/Clients/DataGovClient.php
@@ -22,7 +22,7 @@ class DataGovClient implements IClient, ICachedClient
     /**
      * Корневой адрес запроса к API сервиса
      */
-    const ROOT_URL = 'http://data.gov.ru/api/json/dataset/7708660670-proizvcalendar/version/20151123T183036/content/';
+    const ROOT_URL = 'https://data.gov.ru/api/json/dataset/7708660670-proizvcalendar/version/20151123T183036/content/';
 
     /**
      * Ключи данных API сервиса
@@ -198,6 +198,7 @@ class DataGovClient implements IClient, ICachedClient
             CURLOPT_CONNECTTIMEOUT => $this->connectTimeout,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FAILONERROR    => true,
+            CURLOPT_FOLLOWLOCATION => true,
         ]);
         $response = curl_exec($curl);
 


### PR DESCRIPTION
Исправлена в коде ссылка на https, и добавлено следование редиректам на случай подобной ситуации в будущем.