### PR TITLE
Fix findPreHolidayDay function / not found date with first zero

### DIFF
--- a/src/Month.php
+++ b/src/Month.php
@@ -108,6 +108,8 @@ class Month
     {
         $d = (int)$d;
 
+        if (strlen($d) == 1) $d = '0' . $d;
+
         if (!isset($this->preHolidayDays[$d])) {
             throw new CalendarException("Day «{$d}» not found");
         }


### PR DESCRIPTION
Не ищет предвыходные дни, начинающиеся с нуля, т.к. перед эти их переводит в int 
Можно было бы убрать перевод в int, но вдруг это для чего-то нужно, поэтому после перевода в int и до поиска  добавлена подстановка первоначального 0 к значениям с длиной строки равным 1