### PR TITLE
Замена домена xmlcalendar.ru на xmlcalendar.github.io

### DIFF
--- a/src/Clients/XmlCalendarClient.php
+++ b/src/Clients/XmlCalendarClient.php
@@ -78,7 +78,7 @@ class XmlCalendarClient implements IClient
             if (!isset($this->data[$this->country][$numberY])) {
                 try {
                     $contents = $this->curl->request(sprintf(
-                        'http://xmlcalendar.ru/data/%s/%s/calendar.json',
+                        'https://xmlcalendar.github.io/data/%s/%s/calendar.json',
                         $this->country,
                         $numberY
                     ));


### PR DESCRIPTION
У домена xmlcalendar.ru закончилась регистрация домена, по данным как я понял он соответствует репозиторию xmlcalendar.github.io. Возможно даже в случае продления имеет смысл оставить домен xmlcalendar.github.io, т.к. он не зависит от продления и будет жив, пока жив репозиторий